### PR TITLE
add s3 parameter to CONFIG_FILE_ARGUMENTS

### DIFF
--- a/formica/cli.py
+++ b/formica/cli.py
@@ -47,7 +47,8 @@ CONFIG_FILE_ARGUMENTS = {
     'failure_tolerance_percentage': int,
     'max_concurrent_count': int,
     'max_concurrent_percentage': int,
-    'resource_types': bool
+    'resource_types': bool,
+    's3': bool
 }
 
 


### PR DESCRIPTION
Adding s3 parameter to "CONFIG_FILE_ARGUMENTS" in  order to have s3 option in config file.