### PR TITLE
Organization variables for region and account (#147)

### DIFF
--- a/formica/cli.py
+++ b/formica/cli.py
@@ -44,6 +44,8 @@ CONFIG_FILE_ARGUMENTS = {
     "all_regions": bool,
     "excluded_regions": list,
     "organization_variables": bool,
+    "organization_region_variables": bool,
+    "organization_account_variables": bool,
     "region_order": list,
     "failure_tolerance_count": int,
     "failure_tolerance_percentage": int,
@@ -444,6 +446,18 @@ def add_organization_account_template_variables(parser):
     parser.add_argument(
         "--organization-variables",
         help="Add AWSAccounts, AWSSubAccounts, AWSMainAccount and AWSRegions as Jinja variables with an Email, Id and Name field for each account",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--organization-region-variables",
+        help="Add AWSRegions as Jinja variables",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--organization-account-variables",
+        help="Add AWSAccounts, AWSSubAccounts, and AWSMainAccount as Jinja variables with an Email, Id, and Name field for each account",
         action="store_true",
         default=False,
     )

--- a/formica/helper.py
+++ b/formica/helper.py
@@ -8,6 +8,11 @@ def collect_vars(args):
     variables = args.vars or {}
     if args.organization_variables:
         variables.update(accounts_and_regions())
+    else:
+        if args.organization_region_variables:
+            variables.update(aws_regions())
+        if args.organization_account_variables:
+            variables.update(aws_accounts())    
     return variables
 
 

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -60,3 +60,70 @@ def test_with_organization_variables(aws_client, aws_session, tmpdir, logger, pa
                                                         'Name': 'TestName1'},
                                   'ModuleRegions': ['us-west-1', 'us-west-2'], 'Regions': ['us-west-1', 'us-west-2']}}
     assert actual == expected
+
+
+def test_with_organization_region_variables_no_account_variables(aws_client, aws_session, tmpdir, logger, paginators):
+    aws_client.get_paginator.side_effect = paginators(list_accounts=[ACCOUNTS])
+    aws_client.describe_regions.return_value = EC2_REGIONS
+    aws_client.get_caller_identity.return_value = {'Account': '1234'}
+    example = '{"Resources": {"Accounts": {{ AWSAccounts | tojson }}, "SubAccounts": {{ AWSSubAccounts | tojson }}, "Regions": {{ AWSRegions | tojson }}, "MainAccount": {{ AWSMainAccount | tojson }}}}'
+    with Path(tmpdir):
+        with open('test.template.json', 'w') as f:
+            f.write(example)
+
+        # CLI now raises a TypeError because {{AWSAccounts}} and other account variables are null and cannot be json-serialized
+        with pytest.raises(TypeError):
+            cli.main(['template', '--organization-region-variables'])
+
+
+def test_with_organization_region_variables(aws_client, aws_session, tmpdir, logger, paginators):
+    aws_client.get_paginator.side_effect = paginators(list_accounts=[ACCOUNTS])
+    aws_client.describe_regions.return_value = EC2_REGIONS
+    aws_client.get_caller_identity.return_value = {'Account': '1234'}
+    example = '{"Resources": {"Regions": {{ AWSRegions | tojson }}}}'
+    with Path(tmpdir):
+        with open('test.template.json', 'w') as f:
+            f.write(example)
+
+        cli.main(['template', '--organization-region-variables'])
+        logger.info.assert_called()
+        output = logger.info.call_args[0][0]
+
+        actual = yaml.load(output)
+        expected = {'Resources': {'Regions': ['us-west-1', 'us-west-2'], 'Regions': ['us-west-1', 'us-west-2']}}
+    assert actual == expected
+
+
+def test_with_organization_account_variables_no_region_variables(aws_client, aws_session, tmpdir, logger, paginators):
+    aws_client.get_paginator.side_effect = paginators(list_accounts=[ACCOUNTS])
+    aws_client.describe_regions.return_value = EC2_REGIONS
+    aws_client.get_caller_identity.return_value = {'Account': '1234'}
+    example = '{"Resources": {"Accounts": {{ AWSAccounts | tojson }}, "SubAccounts": {{ AWSSubAccounts | tojson }}, "Regions": {{ AWSRegions | tojson }}, "MainAccount": {{ AWSMainAccount | tojson }}}}'
+    with Path(tmpdir):
+        with open('test.template.json', 'w') as f:
+            f.write(example)
+
+        # CLI now raises a TypeError because {{AWSRegions}} is null and cannot be json-serialized
+        with pytest.raises(TypeError):
+            cli.main(['template', '--organization-account-variables'])
+
+
+def test_with_organization_account_variables(aws_client, aws_session, tmpdir, logger, paginators):
+    aws_client.get_paginator.side_effect = paginators(list_accounts=[ACCOUNTS])
+    aws_client.describe_regions.return_value = EC2_REGIONS
+    aws_client.get_caller_identity.return_value = {'Account': '1234'}
+    example = '{"Resources": {"Accounts": {{ AWSAccounts | tojson }}, "SubAccounts": {{ AWSSubAccounts | tojson }}, "MainAccount": {{ AWSMainAccount | tojson }}}}'
+    with Path(tmpdir):
+        with open('test.template.json', 'w') as f:
+            f.write(example)
+
+        cli.main(['template', '--organization-account-variables'])
+        logger.info.assert_called()
+        output = logger.info.call_args[0][0]
+
+        actual = yaml.load(output)
+        expected = {'Resources': {'Accounts': [{'Email': 'email1@test.com', 'Id': '1234', 'Name': 'TestName1'},
+                                               {'Email': 'email2@test.com', 'Id': '5678', 'Name': 'TestName2'}],
+                                  'SubAccounts': [{'Email': 'email2@test.com', 'Id': '5678', 'Name': 'TestName2'}],
+                                  'MainAccount': {'Email': 'email1@test.com', 'Id': '1234', 'Name': 'TestName1'}}}
+    assert actual == expected


### PR DESCRIPTION
This PR introduces two new CLI options, `--organization-region-variables` and `--organization-account-variables`, which add region- and account-related variables to the template context, respectively. 