### PR TITLE
Use regex to be case-insensitive regardless of file system (#151)

### DIFF
--- a/formica/loader.py
+++ b/formica/loader.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import sys
+import re
 
 import logging
 import yaml
@@ -137,7 +138,7 @@ class Loader(object):
             logger.info("File {} is empty".format(file))
 
     def load_module(self, module_path, element_key, element_value):
-        module_path = self.path + "/" + "/".join(module_path.lower().split("::"))
+        module_path = self.path + "/" + "/".join(module_path.split("::"))
         file_name = "*"
 
         if not os.path.isdir(module_path):
@@ -164,7 +165,8 @@ class Loader(object):
         files = []
 
         for file_type in FILE_TYPES:
-            files.extend(glob.glob("{}/{}.template.{}".format(self.path, self.filename, file_type)))
+            pattern = re.compile(fnmatch.translate("{}.template.{}".format(self.filename, file_type)), re.IGNORECASE)
+            files.extend([filename for filename in os.listdir(self.path) if pattern.match(filename)])
 
         if not files:
             logger.info("Could not find any template files in {}".format(self.path))

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -178,6 +178,34 @@ def test_template_loads_submodules_with_specific_file(load, tmpdir):
     assert actual == {"Description": "test"}
 
 
+def test_template_loads_submodule_case_insensitive(load, tmpdir):
+    example = '{"Description": "{{ \'test\'}}"}'
+    with Path(tmpdir):
+        os.mkdir('moduledir')
+        with open('moduledir/TesT.template.json', 'w') as f:
+            f.write(example)
+        with open('test.template.json', 'w') as f:
+            f.write(json.dumps({'Resources': {'TestResource': {'From': 'Moduledir'}}}))
+        load.load()
+        actual = json.loads(load.template())
+    assert actual == {"Description": "test"}
+
+
+def test_template_loads_submodules_with_specific_file(load, tmpdir):
+    example = '{"Description": "{{ \'test\'}}"}'
+    with Path(tmpdir):
+        os.mkdir('moduledir')
+        with open('moduledir/TesT.template.json', 'w') as f:
+            f.write(example)
+        with open('moduledir/test2.template.yml', 'w') as f:
+            f.write('Sometestthing: does not fail')
+        with open('test.template.json', 'w') as f:
+            f.write(json.dumps({'Resources': {'TestResource': {'From': 'ModuleDir::tESt'}}}))
+        load.load()
+        actual = json.loads(load.template())
+    assert actual == {"Description": "test"}
+
+
 def test_template_submodule_loads_variables(load, tmpdir):
     example = '{"Description": "{{ test }}"}'
     with Path(tmpdir):


### PR DESCRIPTION
Bypasses the inconsistent case sensitivity of file systems by using an always-case-insensitive regex.