### PR TITLE
Allow to specify --profile parameter for template command (#161)

### DIFF
--- a/formica/cli.py
+++ b/formica/cli.py
@@ -100,6 +100,7 @@ def main(cli_args):
     template_parser.add_argument("-y", "--yaml", help="print output as yaml", action="store_true")
     add_artifacts_argument(template_parser)
     add_organization_account_template_variables(template_parser)
+    add_aws_arguments(template_parser)
     template_parser.set_defaults(func=template)
 
     # Stacks Command Arguments

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -76,3 +76,12 @@ def test_fails_with_wrong_parameter_format(capsys):
     out, err = capsys.readouterr()
     assert "argument --parameters: Test:Test needs to be in format KEY=VALUE" in err
     assert pytest_wrapped_e.value.code == 2
+
+
+def test_can_provide_profile_for_template_comand(capsys):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        cli.main(['template', '--profile', 'testAwsCliProfile'])
+    out, err = capsys.readouterr()
+    assert "" == out
+
+


### PR DESCRIPTION
This allows to specify the `--profile` command line argument to the `template` command, fixing the issue that no other AWS profile can be used for rendering a template.